### PR TITLE
Direct people to the 'real' ThaliApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ThaliAppMap
 
-The ThaliApp is the app for the studentassociation Thalia. This app is made for
+_For the official ThaliApp please see [Thalia's Technicie Gitlab page](https://gitlab.science.ru.nl/thalia/thaliapp)_
+
+This ThaliApp is the app for the studentassociation Thalia. This app is made for
 the subject Research and Development '14/15 at the Radboud University Nijmegen.
 
 Requirements:


### PR DESCRIPTION
We weren't aware you guys had already used the name ThaliApp. Great minds think alike, I guess. The 'real' ThaliApp is available on Gitlab and in the Google Play store.
